### PR TITLE
Add cloud-platform scope to instance creation

### DIFF
--- a/hermitcrab/command/up.py
+++ b/hermitcrab/command/up.py
@@ -259,8 +259,10 @@ def create_instance(instance_config: InstanceConfig):
             f"--metadata-from-file=user-data={cloudinit_path}",
             f"--disk=name={instance_config.pd_name},device-name={instance_config.pd_name},auto-delete=no",
             # use scopes that are equivilent to 'default' from https://cloud.google.com/sdk/gcloud/reference/compute/instances/create#--scopes
-            # but also add compute-rw so that the instance can suspend itself down when idle.
-            f"--scopes=storage-ro,logging-write,monitoring-write,pubsub,service-management,service-control,trace,compute-rw",
+            # but also add:
+            # - compute-rw so that the instance can suspend itself down when idle.
+            # - cloud-platform so that user credentials can be used with gcloud (e.g. for gumbo client auth without a service account)
+            f"--scopes=storage-ro,logging-write,monitoring-write,pubsub,service-management,service-control,trace,compute-rw,cloud-platform",
             f"--service-account={instance_config.service_account}",
         ]
 


### PR DESCRIPTION
@pgm this is a small change, but I'm not super familiar with the hermit setup, so just wanted to give you a heads up before I merge anything in. 

**Background:**
Yuran was encountering a `gumbo_rest_client` connection issue I hadn't seen before which was only happening on her hermit instance (not when she used the client locally). 
* Error message: "Unable to acquire impersonated credentials ... Request had insufficient authentication scopes."

* And this error was originating from the following line in the client: 
    ```
    impersonated_creds.refresh(google.auth.transport.requests.Request())
    ```

**Solution:**
I suspect the issue is that the compute instance itself needs an additional scope (specifically, [compute-platform](https://developers.google.com/identity/protocols/oauth2/scopes#cloudprofiler)), which can only be set when the instance is created.

I found this similar issue on stackoverflow:
https://stackoverflow.com/questions/35928534/403-request-had-insufficient-authentication-scopes-during-gcloud-container-clu
